### PR TITLE
chore(1.4.0): bump build and source_gen versions, update the deprecat…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,3 +40,7 @@
 ## 1.3.1
 
 - [Lib] Docs: Fix README documentation
+
+## 1.4.0
+
+- [Lib] Chore: bump dependencies

--- a/lib/src/test_code_builder.dart
+++ b/lib/src/test_code_builder.dart
@@ -1,4 +1,4 @@
-import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/element2.dart';
 import 'package:build/build.dart';
 import 'package:code_builder/code_builder.dart';
 import 'package:dart_style/dart_style.dart';
@@ -133,12 +133,12 @@ class TestCodeBuilder extends GeneratorForAnnotation<StepDefinition> {
   Version get dartVersion => Version(3, 8, 0);
 
   @override
-  generateForAnnotatedElement(
-    Element element,
+  Future<String?> generateForAnnotatedElement(
+    Element2 element,
     ConstantReader annotation,
     BuildStep buildStep,
   ) async {
-    final classElement = element as ClassElement;
+    final classElement = element as ClassElement2;
     final lib = LibraryReader(await buildStep.inputLibrary);
 
     final pickledCucumber = PickledCucumber();
@@ -150,22 +150,19 @@ class TestCodeBuilder extends GeneratorForAnnotation<StepDefinition> {
 
     final stepMethods = <StepMethod>[];
     lib.allElements
-        .whereType<ClassElement>()
+        .whereType<ClassElement2>()
         .first // should manage all classes
-        .methods
+        .methods2
         .forEach((methodElement) {
-      for (var meta in methodElement.metadata) {
+      for (var meta in methodElement.metadata2.annotations) {
         // get the value of the annotation
         final value = meta.computeConstantValue();
         final superValue = value?.getField('(super)');
-        if (superValue?.type?.getDisplayString(withNullability: false) ==
-            'GherkinAnnotation') {
+        if (superValue?.type?.getDisplayString() == 'GherkinAnnotation') {
           final annotationValue =
               superValue?.getField('value')?.toStringValue();
           if (annotationValue != null) {
-            final annotationName = value?.type?.getDisplayString(
-              withNullability: false,
-            );
+            final annotationName = value?.type?.getDisplayString();
             stepMethods.add(toStepMethod(
               features,
               "$annotationName $annotationValue",
@@ -180,7 +177,7 @@ class TestCodeBuilder extends GeneratorForAnnotation<StepDefinition> {
     return buildCode(
       featuresInSteps(features, stepMethods),
       stepMethods,
-      classElement.librarySource.uri.pathSegments.last,
+      classElement.library2.uri.pathSegments.last,
       element.displayName,
       pickledCucumber,
     );
@@ -243,7 +240,7 @@ class TestCodeBuilder extends GeneratorForAnnotation<StepDefinition> {
   StepMethod toStepMethod(
     List<Feature> features,
     String stepName,
-    MethodElement methodElement,
+    MethodElement2 methodElement,
     PickledCucumber pickledCucumber,
   ) {
     final methodName = methodElement.displayName;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pickled_cucumber
 description: A simple cucumber implementation for Dart, Dart Frog and Flutter.
-version: 1.3.1
+version: 1.4.0
 repository: https://github.com/PiotrFLEURY/pickled_cucumber
 
 environment:
@@ -9,12 +9,12 @@ environment:
 # Add regular dependencies here.
 dependencies:
   analyzer: ^7.4.5
-  build: ^2.4.1
+  build: ^3.0.0
   code_builder: ^4.9.0
   dart_style: ^3.1.0
   file: ^7.0.0
   test: ^1.24.0
-  source_gen: ^2.0.0
+  source_gen: ^3.0.0
   pub_semver: ^2.2.0
 
 dev_dependencies:


### PR DESCRIPTION
…ed use of analyzer

## Description

I bumped some dependencies to solves conflict with other generation lib as retrofit, json_serializer and riverpod and make the lib compatible with flutter 3.35.6.

Bump build dep to 3.0.0
Bump source_gen dep to 3.0.0
Change deprecated use of analyzer element to element2 (and so on)

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [X] 🗑️ Chore