### PR TITLE
chore(1.6.0): bump analyzer dependenncies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,3 +53,7 @@
 
 - [Lib] Fix: Step methods resolution from library file with multiple classes. Fixes [#51](https://github.com/PiotrFLEURY/pickled_cucumber/issues/51)
 - [Lib] Fix: Only parametrized steps resolution in scenarios. Fixes [#28](https://github.com/PiotrFLEURY/pickled_cucumber/issues/28)
+
+## 1.5.0
+
+- [Lib] Chore: bump analyzer dependency 8.0.0 -> 9.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,6 @@
 - [Lib] Fix: Step methods resolution from library file with multiple classes. Fixes [#51](https://github.com/PiotrFLEURY/pickled_cucumber/issues/51)
 - [Lib] Fix: Only parametrized steps resolution in scenarios. Fixes [#28](https://github.com/PiotrFLEURY/pickled_cucumber/issues/28)
 
-## 1.5.0
+## 1.6.0
 
 - [Lib] Chore: bump analyzer dependency 8.0.0 -> 9.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pickled_cucumber
 description: A simple cucumber implementation for Dart, Dart Frog and Flutter.
-version: 1.5.1
+version: 1.6.0
 repository: https://github.com/PiotrFLEURY/pickled_cucumber
 
 environment:
@@ -8,7 +8,7 @@ environment:
 
 # Add regular dependencies here.
 dependencies:
-  analyzer: ^8.0.0
+  analyzer: ^9.0.0
   build: ^4.0.4
   code_builder: ^4.9.0
   dart_style: ^3.1.0


### PR DESCRIPTION
<!--
I bump the analzer dependency to make compatible with other code generation package (eg : json_annotation, riverpod_generator)
-->

## Description

Bump analyzer dependency

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [X] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore